### PR TITLE
SRE: Retrigger AKS deployments for client and server

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,19 +1,4 @@
-# SRE retrigger: 2026-03-12T09:07:20Z (touch)
-# SRE retrigger: 2026-03-11T09:33:05Z (touch)
-# SRE retrigger: 2026-03-11T09:19:31Z (touch)
-# SRE retrigger: 2026-03-11T09:05:20Z (touch)
-# SRE retrigger: 2026-03-10T09:03:10Z (touch)
-# SRE retrigger: 2026-03-08T09:23:55Z (touch)
-# SRE retrigger: 2026-03-08T09:18:55Z (touch)
-# SRE retrigger: 2026-03-08T09:12:30Z (touch)
-# SRE retrigger: 2026-03-08T09:07:44Z (touch)
-# SRE retrigger: 2026-03-08T09:03:31Z (touch)
-# SRE retrigger: 2026-03-07T09:16:59Z (touch)
-# SRE retrigger: 2026-03-07T09:10:45Z (touch)
-# SRE retrigger: 2026-03-07T09:02:33Z (touch)
-# SRE retrigger: 2026-03-06T09:19:40Z (touch)
-# SRE retrigger: 2026-03-06T09:15:30Z (touch)
-# SRE retrigger: 2026-03-06T09:09:55Z (touch)
+# SRE retrigger: 2026-03-17T09:04:45Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,17 +1,4 @@
-# SRE retrigger: 2026-03-12T09:07:58Z (touch)
-# SRE retrigger: 2026-03-11T09:31:30Z (fix resources)
-# SRE retrigger: 2026-03-11T09:20:22Z (touch)
-# SRE retrigger: 2026-03-11T09:05:40Z (touch)
-# SRE retrigger: 2026-03-10T09:04:20Z (touch)
-# SRE retrigger: 2026-03-08T09:24:45Z (touch)
-# SRE retrigger: 2026-03-08T09:19:35Z (touch)
-# SRE retrigger: 2026-03-08T09:12:55Z (touch)
-# SRE retrigger: 2026-03-07T09:17:35Z (touch)
-# SRE retrigger: 2026-03-07T09:11:20Z (touch)
-# SRE retrigger: 2026-03-07T09:03:45Z (touch)
-# SRE retrigger: 2026-03-06T09:20:20Z (touch)
-# SRE retrigger: 2026-03-06T09:15:45Z (touch)
-# SRE retrigger: 2026-03-06T09:10:30Z (touch)
+# SRE retrigger: 2026-03-17T09:04:45Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This PR touches k8s manifests to retrigger GitHub Actions workflows:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

No functional changes; confirms paths trigger and ensures fresh rollout to AKS.

Context: Scheduled SRE verification run 2026-03-17 09:05 UTC.