### PR TITLE
SRE: Align k8s images with GHCR workflow and retrigger AKS deploys

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: client
-          image: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
+          image: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest # managed by GitHub Actions; base kept for sed replacement
           imagePullPolicy: Always
           env:
             - name: API_SERVER_URL

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest
+          image: ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest # managed by GitHub Actions; base kept for sed replacement
           imagePullPolicy: Always
           env:
             - name: PYTHONUNBUFFERED


### PR DESCRIPTION
Summary:
- Verified GitHub Actions build/deploy use GHCR images at ghcr.io/${{ github.repository }}/tailspin-<component>.
- Ensured k8s manifests keep the base image references expected by workflows (sed replaces to commit-sha at deploy time).
- No imagePullSecrets are present; images are made public by workflow steps.
- Touching manifests to retrigger deployments on merge.

Acceptance:
- On merge to main, both workflows (Client/Server to AKS) should run, building/pushing images publicly and deploying to AKS.
- Client LB should return 200 on '/'; Server should return 200 on '/api/games' within cluster.

Post-merge follow-ups:
- Verify pod rollout and logs in namespace tail-spin.
- Capture external IP for tailspin-client and validate endpoint.
