### PR TITLE
SRE: Retrigger AKS client/server deploy workflows; manifests normalized to public GHCR

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-03-17T09:04:45Z (touch)
+# SRE retrigger: 2026-04-07T09:05:40Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-03-17T09:04:45Z (touch)
+# SRE retrigger: 2026-04-07T09:05:40Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Summary
- AKS sbAKSCluster is currently Stopped (via az aks show). This PR touches k8s manifests to trigger the "Build and Deploy Client to AKS" and "Build and Deploy Server to AKS" workflows when merged.
- Manifests already reference public GHCR images and contain no imagePullSecrets.

Details
- client: k8s/client-deployment.yaml touched, image remains ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
- server: k8s/server-deployment.yaml touched, image remains ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest

Post-merge
- Expect both workflows to run. They will build/push images to GHCR with public visibility and attempt deployment to AKS.
- Given cluster is stopped, deploy steps may fail; logs will serve as evidence.

Refs
- Cluster: rg=sb-aks-rg, name=sbAKSCluster, sub=0b17562a-418b-4922-acd0-9a155008a84d