### PR TITLE
SRE: Retrigger AKS client/server deploy workflows; manifests already aligned to public GHCR (2026-04-08 09:04 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-07T09:05:40Z (touch)
+# SRE retrigger: 2026-04-08T09:04:10Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-07T09:05:40Z (touch)
+# SRE retrigger: 2026-04-08T09:04:20Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: retrigger CI/CD for client and server to build/push GHCR images (public) and attempt deploy to AKS.

Context:
- AKS sbAKSCluster is currently Stopped (evidence below). Deploy steps will likely fail until cluster is started.
- Manifests reference public GHCR images; no imagePullSecrets are present.

Evidence (az aks show):
```
az aks show -g sb-aks-rg -n sbAKSCluster --subscription 0b17562a-418b-4922-acd0-9a155008a84d --query "{power:powerState.code,prov:provisioningState,version:kubernetesVersion,fqdn:fqdn}" -o json
{"power":"Stopped","prov":"Succeeded","version":"1.32.4","fqdn":"sbaksclust-sb-aks-rg-0b1756-fc7nw2dv.hcp.centralindia.azmk8s.io"}
```

Action:
- Touch k8s/*deployment.yaml to trigger both workflows on merge to main.
- After start approval of AKS, we will re-run deployments if needed.
