### PR TITLE
SRE: Retrigger AKS client/server deploy workflows (2026-04-09 09:05 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-08T09:04:10Z (touch)
+# SRE retrigger: 2026-04-09T09:05:00Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-08T09:04:20Z (touch)
+# SRE retrigger: 2026-04-09T09:05:00Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
This PR touches k8s manifests to trigger both deployment workflows on merge to main.

Context:
- AKS sbAKSCluster is currently Stopped; deployments will queue/fail until it is started.
- Tracking Issue: #264

Files touched:
- k8s/client-deployment.yaml
- k8s/server-deployment.yaml

On merge, Actions should run:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

Post-merge, please start the AKS cluster to allow deployments to succeed.