### PR TITLE
SRE: Retrigger AKS client/server deploy workflows (2026-04-10 09:06 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -75,3 +75,4 @@ spec:
 # SRE retrigger: 2026-03-04T09:31:05Z (touch)
 # SRE retrigger: 2026-03-04T09:37:15Z (touch)
 # SRE retrigger: 2026-03-04T09:42:10Z (touch)
+# SRE retrigger: 2026-04-10T09:05:30Z (touch)

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -72,3 +72,4 @@ spec:
 # SRE retrigger: 2026-03-04T09:31:25Z (touch)
 # SRE retrigger: 2026-03-04T09:37:35Z (touch)
 # SRE retrigger: 2026-03-04T09:42:20Z (touch)
+# SRE retrigger: 2026-04-10T09:05:40Z (touch)


### PR DESCRIPTION
Automated daily SRE verification: AKS cluster currently Stopped.

This PR minimally touches k8s manifests to trigger both deploy workflows on merge to main. No functional changes.

- k8s/client-deployment.yaml: touch comment
- k8s/server-deployment.yaml: touch comment

Post-merge, please start the AKS cluster so the deploy steps can apply successfully.