### PR TITLE
SRE: Retrigger CI for client/server; ensure GHCR public; manifests aligned to ghcr.io (no imagePullSecrets)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,3 +1,4 @@
+# SRE retrigger: 2026-04-28T09:10:30Z (touch)
 # SRE retrigger: 2026-04-14T09:03:26Z (touch)
 # SRE retrigger: 2026-04-13T09:03:32Z (touch)
 # SRE retrigger: 2026-04-12T09:02:16Z (touch)

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,3 +1,4 @@
+# SRE retrigger: 2026-04-28T09:10:40Z (touch)
 # SRE retrigger: 2026-04-14T09:03:26Z (touch)
 # SRE retrigger: 2026-04-13T09:04:30Z (touch)
 # SRE retrigger: 2026-04-12T09:02:16Z (touch)


### PR DESCRIPTION
Purpose: CI-first remediation with AKS runtime currently stopped (read-only ops).\n\nChanges:\n- Touched k8s/client-deployment.yaml and k8s/server-deployment.yaml to retrigger pipelines.\n- Confirmed images: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest and ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest.\n- No imagePullSecrets in manifests; rely on public GHCR visibility.\n\nRequest:\n- Dispatch workflows: “Build and Deploy Client to AKS” and “Build and Deploy Server to AKS”.\n- Ensure GHCR packages tailspin-client and tailspin-server are set to Public.\n- Post run URLs/status to Issues #315 and #285; open a new issue assigned to @copilot if any run fails.\n\nContext:\n- AKS: sbAKSCluster (sb-aks-rg, Central India) is Stopped; deferring cluster start pending CI success and approval.