### PR TITLE
SRE: Retrigger CI for client/server; ensure GHCR public; manifests aligned to ghcr.io (no imagePullSecrets)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,3 +1,4 @@
+# SRE retrigger: 2026-04-28T09:18:30Z (touch)
 # SRE retrigger: 2026-04-14T09:03:26Z (touch)
 # SRE retrigger: 2026-04-13T09:03:32Z (touch)
 # SRE retrigger: 2026-04-12T09:02:16Z (touch)

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,3 +1,4 @@
+# SRE retrigger: 2026-04-28T09:19:10Z (touch)
 # SRE retrigger: 2026-04-14T09:03:26Z (touch)
 # SRE retrigger: 2026-04-13T09:04:30Z (touch)
 # SRE retrigger: 2026-04-12T09:02:16Z (touch)


### PR DESCRIPTION
Purpose: Retrigger client/server CI, enforce GHCR public visibility, and validate manifests use ghcr.io images without imagePullSecrets.

Changes:
- Touch comments in k8s/client-deployment.yaml and k8s/server-deployment.yaml to retrigger workflows.
- No functional changes; images already point to ghcr.io and no imagePullSecrets present.

Next steps:
- Dispatch "Build and Deploy Client to AKS" and "Build and Deploy Server to AKS" via workflow_dispatch.
- Ensure GHCR packages tailspin-client and tailspin-server are Public.
- Post run URLs/status to tracking issues and open a new issue if any run or health check fails.