### PR TITLE
SRE: Retrigger AKS client/server deploy via manifest touch (no runtime change)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-29T09:11:00Z (touch)
+# SRE retrigger: 2026-04-30T09:03:24Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-29T09:11:00Z (touch)
+# SRE retrigger: 2026-04-30T09:03:50Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: CI-first retrigger of both AKS deploy workflows by touching k8s manifests (no functional change). Images remain ghcr.io/sombaner/tailspin-toystore/tailspin-{client,server}:latest; no imagePullSecrets.

Notes:
- Workflows set GHCR packages public and render manifests with commit SHA tags.
- AKS sbAKSCluster is currently Stopped; kubectl apply steps may no-op/fail as expected under governance.

On merge, both workflows (Build and Deploy Client to AKS / Server) will run. This is purely to validate build/push paths and artifact visibility.