### PR TITLE
SRE: Retrigger AKS client/server deploy via manifest touch (2026-05-01)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-30T09:03:24Z (touch)
+# SRE retrigger: 2026-05-01T09:03:22Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-04-30T09:03:50Z (touch)
+# SRE retrigger: 2026-05-01T09:03:54Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
CI-first retrigger to run “Build and Deploy Client to AKS” and “Build and Deploy Server to AKS”. No functional changes; manifests touched to trigger workflows. AKS remains Stopped; expect build/push to GHCR to succeed and deploy steps to no-op/fail.