### PR TITLE
SRE: Retrigger AKS client/server deploy via CI (2026-05-02 09:05 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-01T09:12:55Z (touch)
+# SRE retrigger: 2026-05-02T09:05:30Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-01T09:13:55Z (touch)
+# SRE retrigger: 2026-05-02T09:05:45Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: CI-first retrigger of Tailspin client and server AKS deploy workflows.

Summary of changes:
- Touched k8s manifests to retrigger workflows (no functional changes)
- Ensured images reference public GHCR: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest and ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest
- Confirmed no imagePullSecrets are present (public images)

Context:
- AKS sbAKSCluster in sb-aks-rg is currently PowerState=Stopped; deployments will be driven by CI only
- Workflows expected to run: "Build and Deploy Client to AKS" and "Build and Deploy Server to AKS"

Post-merge actions:
- Monitor the two workflow runs and record run URLs in Issue #349