### PR TITLE
SRE: Retrigger AKS client/server deploy via CI (2026-05-04 09:05 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-03T09:03:40Z (touch)
+# SRE retrigger: 2026-05-04T09:04:10Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-03T09:04:05Z (touch)
+# SRE retrigger: 2026-05-04T09:04:35Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: CI-first daily verification at 09:00 UTC. AKS cluster sbAKSCluster is currently PowerState=Stopped; avoiding runtime kubectl actions. This PR touches k8s manifests to retrigger the two deploy workflows which build/push GHCR images (public) and render manifests.

Key points:
- k8s/client-deployment.yaml and k8s/server-deployment.yaml continue to reference public GHCR images (no imagePullSecrets).
- No runtime cluster actions in code; deployment jobs will no-op if the cluster remains Stopped, preserving governance.
- Will track workflow run URLs and outcomes in Issue #360.

AKS state (at 09:04 UTC): { kubernetesVersion: 1.32.4, provisioningState: Succeeded, powerState: Stopped, fqdn: sbaksclust-sb-aks-rg-0b1756-fc7nw2dv.hcp.centralindia.azmk8s.io }