### PR TITLE
SRE: Retrigger AKS client/server deploy via CI (2026-05-05 09:06 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-04T09:04:10Z (touch)
+# SRE retrigger: 2026-05-05T09:05:40Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-04T09:04:35Z (touch)
+# SRE retrigger: 2026-05-05T09:06:30Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: CI-first retrigger of AKS client and server deploy workflows by touching k8s manifests; confirm GHCR images and no imagePullSecrets.

Scope:
- k8s/client-deployment.yaml: confirm image ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest, no imagePullSecrets; touch comment timestamp.
- k8s/server-deployment.yaml: confirm image ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest, no imagePullSecrets; touch comment timestamp.

Notes:
- AKS sbAKSCluster (RG: sb-aks-rg, Sub: 0b17562a-418b-4922-acd0-9a155008a84d) is PowerState=Stopped; apply steps may no-op as per governance.
- Expect Build and Deploy Client to AKS and Build and Deploy Server to AKS to run on merge.

Follow-up:
- I will post the workflow run URLs and final statuses to Issue #368.