### PR TITLE
SRE: Retrigger AKS client/server deploy via CI (2026-05-05 09:22 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:05:40Z (touch)
+# SRE retrigger: 2026-05-05T09:21:30Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:06:30Z (touch)
+# SRE retrigger: 2026-05-05T09:21:40Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: retrigger GitHub Actions "Build and Deploy Client to AKS" and "Build and Deploy Server to AKS" via a minimal, non-functional touch to k8s manifests. Governance: AKS remains Stopped; CI-first only.

Changes:
- k8s/client-deployment.yaml: touch comment; confirm image ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest; no imagePullSecrets.
- k8s/server-deployment.yaml: touch comment; confirm image ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest; no imagePullSecrets.

Notes:
- Workflows render manifests to use ghcr.io/${{ github.repository }}/tailspin-<component>:${{ github.sha }} and make GHCR packages public.
- Expect build jobs to succeed; deploy jobs may no-op/fail due to cluster stopped. We'll not start the cluster.

Post-merge: will capture exact workflow run URLs and statuses in Issue #368.