### PR TITLE
SRE: Retrigger AKS client/server deploy via CI (2026-05-05 09:33 UTC)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:21:30Z (touch)
+# SRE retrigger: 2026-05-05T09:32:46Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:21:40Z (touch)
+# SRE retrigger: 2026-05-05T09:32:46Z (touch)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Purpose: CI-first retrigger of AKS deploy workflows without runtime cluster changes.

Changes:
- Touch comments in k8s/client-deployment.yaml and k8s/server-deployment.yaml with current timestamp to trigger:
  - Build and Deploy Client to AKS
  - Build and Deploy Server to AKS
- No functional changes to images or manifests; images already point to public GHCR; no imagePullSecrets present.

Governance:
- AKS sbAKSCluster is currently PowerState=Stopped; we are not starting the cluster.
- This PR exists purely to re-run CI and publish fresh images.

Post-merge:
- I will record the specific workflow run URLs and final statuses in Issue #368 for auditability.

Rollback:
- Revert the merge commit if needed.