### PR TITLE
SRE: Align k8s images with public GHCR and retrigger AKS deploy workflows

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:32:46Z (touch)
+# SRE retrigger: 2026-05-05T09:39:10Z (touch; confirm GHCR image path and no imagePullSecret)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:32:46Z (touch)
+# SRE retrigger: 2026-05-05T09:39:20Z (touch; confirm GHCR image path and no imagePullSecret)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Summary
- Confirms Kubernetes manifests reference GHCR images (client/server) and contain no imagePullSecrets.
- Touch updates only to retrigger GitHub Actions deploy workflows for client and server.
- CI-first governance: AKS (sbAKSCluster) remains Stopped; no runtime cluster operations.

Files changed
- k8s/client-deployment.yaml: comment touch, confirm ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
- k8s/server-deployment.yaml: comment touch, confirm ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest

Expected outcome
- Triggers workflows:
  • Build and Deploy Client to AKS (.github/workflows/client-deploy-aks.yml)
  • Build and Deploy Server to AKS (.github/workflows/server-deploy-aks.yml)
- Images are built/pushed to GHCR and set to public by workflows.

Governance
- No image pull secrets used; images public.
- No AKS start/attach performed.

Next steps
- After merge, collect exact run URLs and statuses for both workflows and append to Issue #368.