### PR TITLE
SRE: Use public GHCR images in k8s manifests and retrigger client/server AKS deploy workflows

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:39:10Z (touch; confirm GHCR image path and no imagePullSecret)
+# SRE retrigger: 2026-05-06T09:10:45Z (touch; confirm GHCR image path and no imagePullSecret)
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# SRE retrigger: 2026-05-05T09:39:20Z (touch; confirm GHCR image path and no imagePullSecret)
+# SRE retrigger: 2026-05-06T09:10:45Z (touch; confirm GHCR image path and no imagePullSecret)
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Summary
- Ensure Kubernetes manifests reference public GHCR images without imagePullSecrets
- Minimal touch to retrigger GitHub Actions workflows:
  - Build and Deploy Client to AKS
  - Build and Deploy Server to AKS

Details
- client image: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
- server image: ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest
- No imagePullSecrets present; rely on public visibility and unauthenticated pull

Governance
- AKS must remain Stopped; this PR only triggers CI builds and manifest rendering. No runtime cluster start in CI is authorized by policy; the workflows may attempt kubectl but will fail gracefully if cluster is stopped. We’re only verifying CI path.

Next Steps
- After merge, capture workflow run URLs and statuses for the merge SHA on Issue #368.