### PR TITLE
SRE: no-op touch to k8s manifests to trigger client/server deploy workflows

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -67,3 +67,5 @@ spec:
       port: 80
       targetPort: 4321
       protocol: TCP
+
+# no-op: 2026-05-09T09:03Z touch for CI trigger

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -65,3 +65,5 @@ spec:
       protocol: TCP
       port: 5100
       targetPort: 5100
+
+# no-op: 2026-05-09T09:03Z touch for CI trigger


### PR DESCRIPTION
This PR makes a no-op touch to k8s/client-deployment.yaml and k8s/server-deployment.yaml to trigger the path-filtered GitHub Actions:
- Build and Deploy Client to AKS (.github/workflows/client-deploy-aks.yml)
- Build and Deploy Server to AKS (.github/workflows/server-deploy-aks.yml)

Context:
- AKS governance requires CI-first validation; cluster remains Stopped.
- Manifests already reference public GHCR images and have no imagePullSecrets.

Please allow the workflows to run and use their logs for rollout health assessment.