### PR TITLE
SRE: no-op touch to trigger client/server deploy workflows (2026-05-10)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -69,3 +69,4 @@ spec:
       protocol: TCP
 
 # no-op: 2026-05-09T09:03Z touch for CI trigger
+# no-op: 2026-05-10T09:04Z touch for CI trigger

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -67,3 +67,4 @@ spec:
       targetPort: 5100
 
 # no-op: 2026-05-09T09:03Z touch for CI trigger
+# no-op: 2026-05-10T09:05Z touch for CI trigger


### PR DESCRIPTION
Purpose: CI-first validation with AKS cluster stopped. This PR adds no-op timestamp comments to k8s manifests to trigger the path-filtered GitHub Actions:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

Notes:
- Kubernetes manifests reference public GHCR images:
  - ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
  - ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest
- No imagePullSecrets are present.
- Package visibility is managed by workflows to be public.

Post-merge, capture workflow run URLs/statuses and review rollout logs for pod readiness.