### PR TITLE
CI: Trigger AKS client/server deploys; confirm GHCR public images; no imagePullSecrets

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -76,3 +76,4 @@ spec:
 # no-op: 2026-05-11T09:27Z touch for CI trigger
 # no-op: 2026-05-11T09:42Z touch for CI trigger
 # no-op: 2026-05-19T09:06Z touch for CI trigger
+# no-op: 2026-05-19T09:15Z touch for CI trigger

--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -75,3 +75,4 @@ spec:
 # no-op: 2026-05-11T09:22Z touch for CI trigger
 # no-op: 2026-05-11T09:27Z touch for CI trigger
 # no-op: 2026-05-11T09:42Z touch for CI trigger
+# no-op: 2026-05-19T09:06Z touch for CI trigger

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -74,3 +74,4 @@ spec:
 # no-op: 2026-05-11T09:28Z touch for CI trigger
 # no-op: 2026-05-11T09:43Z touch for CI trigger
 # no-op: 2026-05-19T09:06Z touch for CI trigger
+# no-op: 2026-05-19T09:16Z touch for CI trigger

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -73,3 +73,4 @@ spec:
 # no-op: 2026-05-11T09:23Z touch for CI trigger
 # no-op: 2026-05-11T09:28Z touch for CI trigger
 # no-op: 2026-05-11T09:43Z touch for CI trigger
+# no-op: 2026-05-19T09:06Z touch for CI trigger


### PR DESCRIPTION
This PR touches the client and server Kubernetes manifests to trigger the GitHub Actions workflows that build and deploy to AKS.

Summary:
- Manifests reference GHCR images: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest and tailspin-server:latest
- No imagePullSecrets are configured since images are public.
- Workflows will build, push :latest and :${{ github.sha }}, set GHCR packages public, and apply manifests.

Next steps after merge:
- Dispatch/observe runs for both “Build and Deploy Client to AKS” workflows
- Capture run links and AKS pod health/logs in Issue #425
