### PR TITLE
CI: Trigger AKS client/server deploys; confirm GHCR public images; no imagePullSecrets

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -75,3 +75,4 @@ spec:
 # no-op: 2026-05-11T09:22Z touch for CI trigger
 # no-op: 2026-05-11T09:27Z touch for CI trigger
 # no-op: 2026-05-11T09:42Z touch for CI trigger
+# ci-touch: 2026-05-19T09:19Z trigger deploy

--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -76,3 +76,4 @@ spec:
 # no-op: 2026-05-11T09:27Z touch for CI trigger
 # no-op: 2026-05-11T09:42Z touch for CI trigger
 # ci-touch: 2026-05-19T09:19Z trigger deploy
+# ci-touch: 2026-05-19T09:27Z trigger deploy

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -73,3 +73,4 @@ spec:
 # no-op: 2026-05-11T09:23Z touch for CI trigger
 # no-op: 2026-05-11T09:28Z touch for CI trigger
 # no-op: 2026-05-11T09:43Z touch for CI trigger
+# ci-touch: 2026-05-19T09:20Z trigger deploy

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -74,3 +74,4 @@ spec:
 # no-op: 2026-05-11T09:28Z touch for CI trigger
 # no-op: 2026-05-11T09:43Z touch for CI trigger
 # ci-touch: 2026-05-19T09:20Z trigger deploy
+# ci-touch: 2026-05-19T09:27Z trigger deploy


### PR DESCRIPTION
Purpose
- Enforce CI-first deploy to AKS for both client and server
- Ensure manifests reference public GHCR images (no imagePullSecrets)
- Provide auditable trigger for the two workflows: "Build and Deploy Client to AKS" and "Build and Deploy Server to AKS"

Changes
- No functional changes beyond no-op touches to k8s manifests to trigger workflows
- Images remain:
  - ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
  - ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest
- imagePullPolicy: Always; no imagePullSecrets required (public images)

Notes
- Workflows also set GHCR package visibility to public during publish
- AKS cluster may currently be Stopped; deployments may queue/fail until cluster is running. Capture evidence in a follow-up issue.

Next
- On merge (or even on this branch push), confirm both workflows dispatch and collect AKS evidence (pods status, last 50 log lines) for namespace tail-spin.