### PR TITLE
ci-touch: Trigger Client/Server deploy workflows (2026-06-15T09:05Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -104,3 +104,4 @@ spec:
 # ci-touch: 2026-06-13T09:06Z trigger deploy workflows
 # ci-touch: 2026-06-14T09:02Z trigger deploy workflows
 # ci-touch: 2026-06-14T09:07Z trigger deploy workflows
+# ci-touch: 2026-06-15T09:05Z trigger deploy workflows

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -101,3 +101,4 @@ spec:
 # ci-touch: 2026-06-13T09:07Z trigger deploy workflows
 # ci-touch: 2026-06-14T09:02Z trigger deploy workflows
 # ci-touch: 2026-06-14T09:08Z trigger deploy workflows
+# ci-touch: 2026-06-15T09:05Z trigger deploy workflows


### PR DESCRIPTION
AKS sbAKSCluster is currently Stopped (provisioningState Succeeded, k8s 1.32.4). CI-only posture: nudging both client and server deploy workflows via a no-op touch to their manifests. Images remain on public GHCR and no imagePullSecrets are used.

- Client image: ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest
- Server image: ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest

When the cluster starts, we’ll validate pod readiness, services, and logs and update Issue #498 with runtime results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated client and server Kubernetes deployment manifests with timestamp entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->