### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-16-0918Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-16T09:10Z trigger deploy workflows
+# ci-touch: 2026-06-16T09:18Z trigger deploy workflows
 # no functional changes
 # SRE fix: 2026-05-07T09:05Z (confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets)
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-16T09:11Z trigger deploy workflows
+# ci-touch: 2026-06-16T09:18Z trigger deploy workflows
 # no functional changes
 # SRE fix: 2026-05-07T09:05Z (confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets)
 apiVersion: apps/v1


### PR DESCRIPTION
Trigger deploy workflows by touching manifests; AKS remains Stopped so CI-only dispatch. Images use public GHCR paths and no imagePullSecrets. 