### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-16-0925Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,6 +1,6 @@
-# ci-touch: 2026-06-16T09:18Z trigger deploy workflows
+# ci-touch: 2026-06-16T09:25Z trigger deploy workflows (client)
 # no functional changes
-# SRE fix: 2026-05-07T09:05Z (confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets)
+# SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,6 +1,6 @@
-# ci-touch: 2026-06-16T09:18Z trigger deploy workflows
+# ci-touch: 2026-06-16T09:26Z trigger deploy workflows (server)
 # no functional changes
-# SRE fix: 2026-05-07T09:05Z (confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets)
+# SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
CI-only nudge: touch k8s/client-deployment.yaml and k8s/server-deployment.yaml to trigger:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

Notes:
- Images referenced in manifests use public GHCR paths and no imagePullSecrets.
- Workflows will render manifests with SHA-tagged images.
- AKS cluster sbAKSCluster is currently Stopped; deploy steps will likely fail to connect, but build/push and GHCR visibility updates should complete.

Once cluster is Started, follow the post-start AKS validation plan in issue #555.