### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-17-0902Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-16T09:25Z trigger deploy workflows (client)
+# ci-touch: 2026-06-17T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-16T09:26Z trigger deploy workflows (server)
+# ci-touch: 2026-06-17T09:02Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Automated scheduled task (2026-06-17T09:02Z):
- AKS sbAKSCluster is Stopped; proceeding with CI-only redeploy trigger.
- Touch k8s client/server manifests to dispatch both deploy workflows.
- No functional changes; GHCR images remain public; no imagePullSecrets.

This PR exists solely to trigger:
- .github/workflows/client-deploy-aks.yml
- .github/workflows/server-deploy-aks.yml

Post-merge: Monitor workflow runs and validate once AKS is Started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow triggers for client and server services to ensure continuous integration processes execute properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->