### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-18-0902Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-17T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-18T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-17T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-06-18T09:02Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Automated scheduled verification for Tailspin client/server.

Summary:
- AKS `sbAKSCluster` is currently `Stopped`, so live pod/log health checks are not possible in-cluster.
- Manifests already point to public GHCR images and do not use `imagePullSecrets`.
- This PR makes no functional changes; it only updates the `ci-touch` headers in:
  - `k8s/client-deployment.yaml`
  - `k8s/server-deployment.yaml`
- Merging this PR dispatches:
  - `Build and Deploy Client to AKS`
  - `Build and Deploy Server to AKS`

Current verified state:
- Client image: `ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest`
- Server image: `ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest`
- No `imagePullSecrets` configured in either manifest
- AKS power state: `Stopped`

Expected result:
- Build/push to GHCR should proceed
- `kubectl apply` / runtime deployment steps are expected to fail until the cluster is started

Follow-up after cluster start:
- Validate pods, rollouts, services, logs, and endpoint reachability in namespace `tail-spin`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment configuration timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->