### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-19-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-18T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-06-19T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-18T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-06-19T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
AKS `sbAKSCluster` remains `Stopped`, so live pod health checks, pod logs, and endpoint validation are still blocked. This no-op manifest touch dispatches both deploy workflows again so build/push can proceed while the cluster is unavailable.

Summary
- Trigger `Build and Deploy Client to AKS`
- Trigger `Build and Deploy Server to AKS`
- Preserve public GHCR image references
- Keep `imagePullSecrets` absent

Notes
- Client image: `ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest`
- Server image: `ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest`
- Server manifest on `main` still contains the known resource indentation bug; tracked separately in PR #569.
- Expect apply/rollout stages to remain blocked until AKS is started.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration metadata for CI workflow triggers and formatting adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->