### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-20-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-19T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-20T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-19T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-20T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- touch `k8s/client-deployment.yaml` to trigger `Build and Deploy Client to AKS`
- touch `k8s/server-deployment.yaml` to trigger `Build and Deploy Server to AKS`
- keep image references on public GHCR paths with no `imagePullSecrets`

## Why
The AKS cluster `sbAKSCluster` is still `Stopped`, so live pod health checks, pod logs, and endpoint validation remain blocked. This safely re-dispatches both deploy workflows for build/push while preserving the current manifests.

## Notes
- no functional application changes
- server manifest on `main` still contains the known resource indentation defect tracked in #568 / PR #569
- expected outcome: workflows re-run; cluster-backed rollout remains blocked until AKS is started


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configurations to trigger routine CI processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->