### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-21-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-20T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-21T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-20T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-21T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Re-dispatch `Build and Deploy Client to AKS` and `Build and Deploy Server to AKS` via no-op manifest touches while AKS remains stopped.

No functional application changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow trigger timestamps for internal CI/CD processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->