### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-22-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-21T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-22T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-21T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-22T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- Re-dispatch `Build and Deploy Client to AKS`
- Re-dispatch `Build and Deploy Server to AKS`
- No functional manifest changes; touch-only update to trigger workflow runs while AKS runtime validation remains blocked

## Why
- Scheduled verification on 2026-06-22 found AKS cluster `sbAKSCluster` still in `Stopped` state
- Live pod, log, and endpoint validation remain blocked until the cluster is started
- The workflows still build and push images, and may deploy once the cluster is available

## Notes
- Client manifest still references public image `ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest`
- Server manifest still references public image `ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest`
- `imagePullSecrets` are still absent as intended for public GHCR images
- Known server manifest resource indentation bug remains tracked separately in #569