### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-23-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-22T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-23T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-22T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-23T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Automated scheduled verification for 2026-06-23 found AKS cluster `sbAKSCluster` still in `Stopped` state, which blocks live pod/log/endpoint validation.

This PR makes no functional changes. It only updates the `ci-touch` comment timestamps in:
- `k8s/client-deployment.yaml`
- `k8s/server-deployment.yaml`

That safely re-dispatches these existing workflows:
- `Build and Deploy Client to AKS`
- `Build and Deploy Server to AKS`

Context:
- Manifests still reference public GHCR images
- No `imagePullSecrets` are present
- The known server manifest resource indentation bug remains on `main` and is still tracked in `#569`
- Durable fix remains: auto-start AKS before deploy and run post-start validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment infrastructure timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->