### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-24-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-23T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-24T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-23T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-24T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- re-dispatch the client and server AKS deployment workflows by touching both manifests
- preserve public GHCR image references
- keep `imagePullSecrets` absent for public images
- make no functional manifest changes

## Why
The scheduled verification found the AKS cluster `sbAKSCluster` still in `Stopped` state, so live pod, log, rollout, and endpoint validation remain blocked. This PR triggers both GitHub Actions again so build/push and deploy steps re-run once infrastructure is available.

## Validation
- Confirmed `az aks show` reports `powerState: Stopped`, `provisioningState: Succeeded`, `kubernetesVersion: 1.32.4`
- Confirmed workflows still target:
  - `Build and Deploy Client to AKS`
  - `Build and Deploy Server to AKS`
- Confirmed manifests still use public GHCR images and do not include `imagePullSecrets`
- Confirmed the known server manifest resource indentation defect is still present on `main` and remains a separate durable fix item

## Rollback
Revert this PR if the workflow dispatch is not desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI timestamp comments in the client and server deployment files.
  * No application behavior, deployment settings, or service configuration changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->