### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-25-0902Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-24T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-25T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-24T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-25T09:02Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- re-dispatch `Build and Deploy Client to AKS`
- re-dispatch `Build and Deploy Server to AKS`
- make no functional manifest changes

## Why
- scheduled verification on 2026-06-25 found AKS cluster `sbAKSCluster` still in `Stopped` state
- live pod health, logs, rollout checks, and endpoint validation remain blocked until the cluster is started
- this safely retriggers the build/deploy workflows through the existing path filters

## Notes
- client/server manifests still reference public GHCR images
- no `imagePullSecrets` are present
- known server manifest resource indentation defect remains intentionally unchanged here and continues to belong in the durable remediation path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed deployment metadata timestamps in the Kubernetes manifests.
  * No functional changes were made to the application or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->