### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-26-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-25T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-06-26T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-25T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-06-26T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- re-dispatch `Build and Deploy Client to AKS`
- re-dispatch `Build and Deploy Server to AKS`
- preserve current public GHCR image references and no `imagePullSecrets`

## Why
Scheduled verification on 2026-06-26 found `sbAKSCluster` still `Stopped`, so live pod/log/endpoint validation remains blocked. This no-op manifest touch re-triggers the deploy workflows while durable remediation continues separately.

## Validation
- AKS cluster state checked with `az aks show`
- confirmed client and server manifests still reference public GHCR images
- confirmed deploy workflows still trigger on manifest changes

## Notes
- no functional workload changes in this PR
- server manifest resource indentation defect remains for durable fix tracking


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment manifest timestamps for client and server components.
  * No functional configuration or user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->