### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-27-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-26T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-27T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-26T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-27T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Summary
- Scheduled verification on 2026-06-27 found AKS cluster `sbAKSCluster` still `Stopped`
- Live pod health, logs, rollout status, and endpoint checks remain blocked until the cluster is started
- Re-dispatch both deploy workflows by touching only the client and server deployment manifests with updated `ci-touch` comments

Why this change
- The repository is already configured so pushes to `k8s/client-deployment.yaml` and `k8s/server-deployment.yaml` trigger:
  - `Build and Deploy Client to AKS`
  - `Build and Deploy Server to AKS`
- Manifests still reference public GHCR images and do not use `imagePullSecrets`
- This is a low-risk CI redispatch only; no functional manifest change is included

Notes
- `k8s/server-deployment.yaml` still contains the known malformed `resources` indentation and is intentionally left for the durable remediation path
- Expect the build/push stages to run, while apply/rollout may remain blocked until AKS is started

Follow-up required
1. Start AKS cluster `sbAKSCluster`
2. Run post-start validation:
   - `kubectl -n tail-spin get deploy,svc,pods`
   - `kubectl -n tail-spin rollout status deploy/tailspin-server`
   - `kubectl -n tail-spin rollout status deploy/tailspin-client`
   - `kubectl -n tail-spin describe deploy tailspin-server tailspin-client`
   - `kubectl -n tail-spin logs deploy/tailspin-server --tail=200`
3. Validate client `/` and server `/api/games`

Related tracking
- Issue: #568
- Durable remediation path: #569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment metadata timestamps to retrigger client and server deployment workflows.
  * No changes were made to application behavior or Kubernetes configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->