### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-28-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-27T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-28T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-27T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-28T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- touch `k8s/client-deployment.yaml` to trigger the client AKS deploy workflow
- touch `k8s/server-deployment.yaml` to trigger the server AKS deploy workflow
- preserve the current public GHCR image posture and avoid `imagePullSecrets`

## Why
- scheduled 2026-06-28 verification found AKS `sbAKSCluster` still `Stopped`
- live pod, log, rollout, and endpoint validation remain blocked until the cluster is started
- this is the lowest-risk redeploy action while durable remediation continues separately

## Notes
- no functional manifest changes beyond ci-touch comments
- server manifest still has the known malformed `resources` indentation and is intentionally left for the durable remediation path


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment metadata to refresh CI/CD touch timestamps for the client and server services.
  * No functional changes were made to application behavior, configuration, or service setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->