### PR TITLE
Fix legacy games schema migration

### DIFF
--- a/server/tests/test_database_migration.py
+++ b/server/tests/test_database_migration.py
@@ -1,0 +1,77 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+from flask import Flask
+from models import db
+from utils.database import init_db
+
+
+class TestDatabaseMigration(unittest.TestCase):
+    """Test database migrations for legacy game schemas."""
+
+    def setUp(self) -> None:
+        """Create a legacy SQLite database file for migration tests."""
+        handle = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = handle.name
+        handle.close()
+
+        connection = sqlite3.connect(self.db_path)
+        connection.execute(
+            """
+            CREATE TABLE games (
+                id INTEGER PRIMARY KEY,
+                title VARCHAR(100) NOT NULL,
+                description TEXT NOT NULL,
+                star_rating FLOAT,
+                category_id INTEGER NOT NULL,
+                publisher_id INTEGER NOT NULL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO games (title, description, star_rating, category_id, publisher_id)
+            VALUES ('Legacy Game', 'A legacy record that must survive migration.', 4.0, 1, 1)
+            """
+        )
+        connection.commit()
+        connection.close()
+
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.app.config["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{self.db_path}"
+        self.app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+        init_db(self.app, connection_string=f"sqlite:///{self.db_path}", testing=True)
+
+    def tearDown(self) -> None:
+        """Dispose of the database and remove the temporary file."""
+        with self.app.app_context():
+            db.session.remove()
+            db.engine.dispose()
+
+        os.unlink(self.db_path)
+
+    def test_legacy_games_table_is_upgraded(self) -> None:
+        """Legacy game rows gain the columns needed by the API."""
+        connection = sqlite3.connect(self.db_path)
+        try:
+            columns = [row[1] for row in connection.execute("PRAGMA table_info(games)")]
+            self.assertIn("popularity", columns)
+            self.assertIn("release_date", columns)
+            self.assertIn("price", columns)
+
+            row = connection.execute(
+                "SELECT title, popularity, price, release_date FROM games WHERE title = ?",
+                ("Legacy Game",),
+            ).fetchone()
+            self.assertEqual(row[0], "Legacy Game")
+            self.assertEqual(row[1], 0)
+            self.assertEqual(row[2], 0.0)
+            self.assertIsNone(row[3])
+        finally:
+            connection.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/utils/database.py
+++ b/server/utils/database.py
@@ -1,5 +1,6 @@
 import os
-from models import init_db as models_init_db
+from sqlalchemy import inspect, text
+from models import db, init_db as models_init_db
 
 def init_db(app, connection_string=None, testing=False):
     """
@@ -16,6 +17,8 @@ def init_db(app, connection_string=None, testing=False):
     app.config['SQLALCHEMY_DATABASE_URI'] = connection_string
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     models_init_db(app, testing=testing)
+    with app.app_context():
+        _migrate_games_table()
 
 def __get_connection_string():
     """
@@ -31,3 +34,32 @@ def __get_connection_string():
     os.makedirs(data_dir, exist_ok=True)
     
     return f'sqlite:///{os.path.join(data_dir, "tailspin-toys.db")}'
+
+
+def _migrate_games_table() -> None:
+    """Bring the legacy games table up to date for the current model."""
+    inspector = inspect(db.engine)
+    if "games" not in inspector.get_table_names():
+        return
+
+    existing_columns = {column["name"] for column in inspector.get_columns("games")}
+    migrations = []
+
+    if "popularity" not in existing_columns:
+        migrations.append("ALTER TABLE games ADD COLUMN popularity INTEGER DEFAULT 0")
+    if "release_date" not in existing_columns:
+        migrations.append("ALTER TABLE games ADD COLUMN release_date DATE")
+    if "price" not in existing_columns:
+        migrations.append("ALTER TABLE games ADD COLUMN price FLOAT DEFAULT 0.0")
+
+    if not migrations:
+        return
+
+    with db.engine.begin() as connection:
+        for statement in migrations:
+            connection.execute(text(statement))
+
+        if "popularity" not in existing_columns:
+            connection.execute(text("UPDATE games SET popularity = COALESCE(popularity, 0)"))
+        if "price" not in existing_columns:
+            connection.execute(text("UPDATE games SET price = COALESCE(price, 0.0)"))


### PR DESCRIPTION
The featured games page was failing because the checked-in SQLite database still had an older `games` table schema that did not include the columns expected by the current API.

This change adds a startup migration that upgrades legacy `games` tables before Flask serves requests, so the existing data can be read without manually rebuilding the database. It also adds a regression test that seeds the older schema and verifies the migration adds the missing columns and preserves rows.

Testing:
- `./scripts/run-server-tests.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization to automatically upgrade older game tables to the current structure.
  * Existing game records now keep working after the upgrade, with sensible default values filled in for new fields.
  * Added test coverage to verify legacy databases are migrated correctly during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->