### PR TITLE
chore(ci): dispatch client/server deploy workflows via manifest touch (2026-06-30-0901Z)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-29T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-06-30T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-06-29T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-06-30T09:01Z trigger deploy workflows (server)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- scheduled 2026-06-30 verification found AKS `sbAKSCluster` still `Stopped`
- touch `k8s/client-deployment.yaml` and `k8s/server-deployment.yaml` only to dispatch both deploy workflows
- preserve public GHCR image references and no `imagePullSecrets`

## Why
Live pod health, logs, rollout checks, and endpoint validation remain blocked until the cluster is started. This keeps the lowest-risk daily redeploy path active while durable remediation continues separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment timestamp comments in the Kubernetes manifests to refresh automated workflow triggers.
  * No application behavior, configuration, or deployment settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->