### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-07-27T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-07-29T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-07-27T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-07-29T09:02Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- refresh ci-touch markers in client and server AKS manifests
- trigger both AKS deployment workflows for scheduled verification
- keep GHCR image paths aligned with workflow rendering and public package usage

## Why
The Tailspin application is currently down/unverified because AKS cluster `sbAKSCluster` remains `Stopped`. Runtime validation and pod/log inspection are blocked until the cluster is started, but dispatching both workflows now refreshes image build/push and deployment attempts for post-start recovery.

## Validation
- Verified AKS cluster `sbAKSCluster` is `Stopped`
- Verified `k8s/client-deployment.yaml` and `k8s/server-deployment.yaml` still reference:
  - `ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest`
  - `ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest`
- Verified workflows `Build and Deploy Client to AKS` and `Build and Deploy Server to AKS` render commit-specific GHCR tags from those base images

## Expected outcome
- GitHub Actions should rebuild/push the client and server images
- Deploy steps may still fail or remain blocked while AKS stays stopped
- Next required Azure action remains starting `sbAKSCluster` and then validating pods, services, logs, and endpoint reachability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow timestamps for the client and server.
  * No functional or configuration changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->