### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-07-29T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-07-30T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-07-29T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-07-30T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- refresh ci-touch markers in client and server AKS manifests
- trigger both AKS deployment workflows for the 2026-07-30 scheduled verification
- preserve public GHCR image references and no imagePullSecrets

## Why
AKS cluster `sbAKSCluster` is still `Stopped`, so runtime validation, pod checks, logs, and endpoint reachability remain blocked. Re-dispatching both workflows refreshes build/push and deployment attempts for post-start recovery.

## Validation
- Verified AKS cluster `sbAKSCluster` is `Stopped`
- Verified `k8s/client-deployment.yaml` still references `ghcr.io/sombaner/tailspin-toystore/tailspin-client:latest`
- Verified `k8s/server-deployment.yaml` still references `ghcr.io/sombaner/tailspin-toystore/tailspin-server:latest`
- Verified both deploy workflows support push on manifest paths and `workflow_dispatch`

## Expected outcome
- GitHub Actions should rebuild/push the client and server images
- Deploy steps may still fail while AKS stays stopped
- Next required action remains starting `sbAKSCluster` and then validating pods, services, logs, and endpoint reachability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow trigger timestamps for the client and server services.
  * No application behavior or deployment configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->