### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-07-31T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-08-01T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-07-31T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-08-01T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
This non-functional change refreshes the ci-touch comments in the client and server AKS deployment manifests so the existing GitHub Actions workflows run again from a push to `main`.

Why:
- AKS cluster `sbAKSCluster` is still `Stopped`
- runtime pod/log/endpoint validation remains blocked until the cluster is started
- retriggering the workflows keeps the build/deploy path warm and records another scheduled verification run

Files touched:
- `k8s/client-deployment.yaml`
- `k8s/server-deployment.yaml`

No functional manifest changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration timestamps to trigger the latest CI process.
  * No changes to Kubernetes deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->