### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-01T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-02T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-01T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-02T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- touch client and server deployment manifests to retrigger the AKS deploy workflows
- keep image references aligned to public GHCR images
- make no functional workload changes

## Why
Scheduled verification found AKS still stopped, so live validation is blocked. This PR safely retriggers:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

Once the cluster is started, post-start validation is still required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI trigger timestamps in deployment configuration files.
  * No changes to deployment behavior or runtime functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->