### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-02T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-03T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-02T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-03T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Scheduled verification for 2026-08-03.

This is a no-op manifest touch to retrigger:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

Notes:
- No functional manifest changes
- GHCR image references remain public
- No imagePullSecrets are present
- Runtime validation is still blocked because AKS cluster `sbAKSCluster` is `Stopped`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration timestamps for the latest CI refresh.
  * No functional deployment settings or application behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->