### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-03T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-04T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-03T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-04T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Summary
- touch client and server deployment manifests with updated `ci-touch` headers only
- retrigger the client and server AKS deploy workflows for scheduled verification
- preserve public GHCR image references and no `imagePullSecrets`

## Why
AKS cluster `sbAKSCluster` remains `Stopped`, which blocks live pod/log/app validation. This safe no-op PR retriggers CI so builds and deploy attempts are refreshed for the current scheduled verification run.

## Changes
- `k8s/client-deployment.yaml`: header comment timestamp only
- `k8s/server-deployment.yaml`: header comment timestamp only

No functional manifest changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration timestamps to trigger the latest CI workflow.
  * No changes to Kubernetes deployment behavior or runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->