### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-04T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-05T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-04T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-05T09:02Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Scheduled verification 2026-08-05: touch client and server manifests to retrigger AKS deploy workflows while preserving public GHCR image references and no imagePullSecrets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration timestamps used by CI.
  * No changes to application behavior or deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->