### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-05T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-08-06T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-05T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-08-06T09:02Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
Daily SRE verification found AKS `sbAKSCluster` still stopped, so live Tailspin pod/log/app checks remain blocked. This no-op manifest-touch PR retriggers both deploy workflows:
- Build and Deploy Client to AKS
- Build and Deploy Server to AKS

No functional manifest changes beyond refreshing the `ci-touch` timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configuration timestamps to trigger the latest CI/deployment workflow.
  - No application behavior or deployment settings changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->