### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-06T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-08-07T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-06T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-08-07T09:02Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
CI-only redeploy trigger for scheduled verification.

- touches `k8s/client-deployment.yaml`
- touches `k8s/server-deployment.yaml`
- no functional manifest changes beyond refreshed `ci-touch` timestamps
- intended to retrigger:
  - `Build and Deploy Client to AKS`
  - `Build and Deploy Server to AKS`

AKS `sbAKSCluster` is still stopped, so build/push may proceed but AKS apply/rollout steps can remain blocked until the cluster is started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration timestamps to trigger the CI workflow.
  * No changes to application behavior or deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->