### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows for scheduled verification

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-07T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-08-08T09:02Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-07T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-08-08T09:02Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Purpose
Dispatch the existing `Build and Deploy Client to AKS` and `Build and Deploy Server to AKS` workflows after the scheduled verification found `sbAKSCluster` and `nodepool1` still stopped.

## Change
- Updates only the `ci-touch` timestamp comments in `k8s/client-deployment.yaml` and `k8s/server-deployment.yaml`.
- No functional deployment, image, resource, probe, service, or pull-secret configuration changes.

## Expected outcome
The workflows will build and publish the current client/server GHCR images. Their AKS apply and rollout steps cannot complete until `sbAKSCluster` is started.

## Rollback
Revert this PR's single commit; no runtime configuration change is introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration timestamps to trigger the latest CI/CD run.
  * No changes to application behavior or deployment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->