### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows (2026-08-09)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-08T09:02Z trigger deploy workflows (client)
+# ci-touch: 2026-08-09T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-08T09:02Z trigger deploy workflows (server)
+# ci-touch: 2026-08-09T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Scheduled SRE CI dispatch

The AKS cluster `sbAKSCluster` and `nodepool1` remain `Stopped`, so Tailspin is unavailable and runtime validation cannot run.

This PR changes only the `ci-touch` timestamp comments in:
- `k8s/client-deployment.yaml`
- `k8s/server-deployment.yaml`

Merging to `main` triggers the existing path-filtered workflows:
- **Build and Deploy Client to AKS**
- **Build and Deploy Server to AKS**

No image paths, probes, resources, Services, or image-pull-secret settings are changed. Rollback: revert the resulting squash commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment metadata timestamps for the client and server.
  * No changes to Kubernetes configuration or application runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->