### PR TITLE
chore(ci): dispatch client/server AKS deploy workflows (2026-08-10)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-09T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-10T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-09T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-10T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Scheduled SRE CI dispatch

AKS cluster `sbAKSCluster` and `nodepool1` are `Stopped`, so Tailspin is unavailable and runtime validation cannot run.

This PR changes only the `ci-touch` timestamp comments in:
- `k8s/client-deployment.yaml`
- `k8s/server-deployment.yaml`

Merging to `main` invokes the existing path-filtered workflows:
- **Build and Deploy Client to AKS**
- **Build and Deploy Server to AKS**

No image paths, probes, resources, Services, or image-pull-secret settings are changed. Rollback: revert the resulting squash commit.