### PR TITLE
chore(ci): dispatch client/server deploy workflows (2026-08-11)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-10T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-11T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-10T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-11T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Purpose
AKS `sbAKSCluster` and `nodepool1` remain `Stopped`, making the Tailspin application unavailable and preventing current pod/log/endpoint validation. This PR re-triggers the repository’s configured client and server deployment workflows once merged to `main`.

## Scope
- Updates only the `ci-touch` comment in `k8s/client-deployment.yaml`.
- Updates only the `ci-touch` comment in `k8s/server-deployment.yaml`.
- No changes to images, image pull policy, secrets, resources, probes, services, or runtime behavior.

## Validation
- Verified each workflow is path-filtered on its respective deployment manifest.
- Verified images reference public GHCR paths and no `imagePullSecrets` are configured.
- Verified this commit is exactly 2 additions and 2 deletions, limited to the comments above.

## Expected outcome
Both Actions build/push their images. AKS apply/rollout stages may remain blocked until `sbAKSCluster` is started.

## Rollback
Revert the merge commit if this dispatch is no longer needed.

Tracks #568.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment metadata timestamps for the client and server services.
  * No changes to application functionality or deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->