### PR TITLE
chore(ci): dispatch client and server AKS deploy workflows (2026-08-12)

### DIFF
--- a/k8s/client-deployment.yaml
+++ b/k8s/client-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-11T09:01Z trigger deploy workflows (client)
+# ci-touch: 2026-08-12T09:01Z trigger deploy workflows (client)
 # no functional changes
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1

--- a/k8s/server-deployment.yaml
+++ b/k8s/server-deployment.yaml
@@ -1,4 +1,4 @@
-# ci-touch: 2026-08-11T09:01Z trigger deploy workflows (server)
+# ci-touch: 2026-08-12T09:01Z trigger deploy workflows (server)
 # functional fix: correct resources.requests.memory indentation
 # SRE fix: confirm GHCR image path matches workflow; ensure image is public; no imagePullSecrets
 apiVersion: apps/v1


### PR DESCRIPTION
## Purpose
Tailspin is unavailable because `sbAKSCluster` and `nodepool1` are stopped. This comment-only change activates the path-filtered **Build and Deploy Client to AKS** and **Build and Deploy Server to AKS** workflows.

## Change
- Updates only the `ci-touch` timestamps in `k8s/client-deployment.yaml` and `k8s/server-deployment.yaml`.
- No image, probe, resource, Service, secret, or application configuration changed.

## Verification
- Diff: 2 additions / 2 deletions; timestamp comments only.
- Workflows use public GHCR image paths and no `imagePullSecrets`.

## Expected limitation
Build/push stages may run, but AKS deployment stages cannot complete until `sbAKSCluster` is started.

## Rollback
Revert the resulting merge commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment metadata timestamps for the latest CI refresh.
  * No changes to Kubernetes deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->